### PR TITLE
fix(home): pin hero card meta to bottom and keep player at 16:9

### DIFF
--- a/frontend/src/features/home/components/HeroMediaCard.jsx
+++ b/frontend/src/features/home/components/HeroMediaCard.jsx
@@ -55,7 +55,7 @@ function AuthorName({ href, name }) {
 	);
 }
 
-export function HeroMediaCard({ className = '', media }) {
+export function HeroMediaCard({ className = '', media, style, isDesktop = false }) {
 	if (!media) {
 		return null;
 	}
@@ -67,8 +67,18 @@ export function HeroMediaCard({ className = '', media }) {
 	const mediaHref = getMediaHref(media);
 
 	return (
-		<div className={cn('w-full min-w-0', className)}>
-			<Card className="flex h-full min-h-[360px] flex-col justify-between gap-8 overflow-hidden px-[22px] pb-6 pt-[22px] lg:min-h-0">
+		<div className={cn('flex min-w-0 flex-col', className)} style={style}>
+			<Card
+				className={cn(
+					// justify-between pins the author/country/views block to the card bottom
+					// when the summary is short (the spare height goes into the gap). When the
+					// summary is long there is no spare height, so the groups sit at the gap-4
+					// minimum (16px) and the card grows past its floor without clipping. The
+					// card fills its minHeight floor via flex-1.
+					'flex flex-1 flex-col justify-between gap-4 overflow-hidden px-[22px] pb-6 pt-[22px]',
+					isDesktop ? '' : 'min-h-[360px]'
+				)}
+			>
 				<div className="flex min-w-0 flex-col gap-3">
 					<Text as="h2" variant="h6" className="m-0 max-w-full overflow-hidden break-words text-text-primary">
 						{mediaHref ? (
@@ -87,7 +97,13 @@ export function HeroMediaCard({ className = '', media }) {
 						<Text
 							variant="body-14"
 							color="description"
-							className="m-0 max-h-[260px] overflow-hidden lg:max-h-[280px]"
+							// The card height is a floor, not a cap (see heroCardStyle and
+							// the flex-1 card), so the full text always renders and the card
+							// grows when needed. The displayed field is `summary`, capped at
+							// 60 words server-side (files/forms.py clean_summary);
+							// `description` is the rare unbounded fallback used only when
+							// summary is empty.
+							className="m-0"
 						>
 							{description}
 						</Text>
@@ -122,9 +138,9 @@ export function HeroMediaCard({ className = '', media }) {
 	);
 }
 
-export function HeroMediaCardSkeleton({ className = '' }) {
+export function HeroMediaCardSkeleton({ className = '', style }) {
 	return (
-		<Card as="div" className={cn('w-full min-w-0 p-[22px]', className)}>
+		<Card as="div" className={cn('min-w-0 p-[22px]', className)} style={style}>
 			<div className="h-8 w-3/4 animate-pulse rounded bg-bg-skeleton" />
 			<div className="mt-3 h-4 w-1/2 animate-pulse rounded bg-bg-skeleton" />
 		</Card>

--- a/frontend/src/features/home/components/HeroSection.jsx
+++ b/frontend/src/features/home/components/HeroSection.jsx
@@ -12,16 +12,73 @@ import HeroPlayButtonIcon from '../../shared/icons/hero-play-button.svg?react';
 
 const HeroContext = createContext(null);
 
-const HERO_DESKTOP_MIN_WIDTH = 1175;
+// Two-column layout engages by VIEWPORT width at the common 1366px laptop width.
+// The common desktop CSS widths are 1280, 1366, 1440, 1536, 1920; 1366 and above
+// render two columns (1366, 1440, 1536, 1920) and below it (1024, 1280) renders
+// one column in both sidebar states. Two columns at 1280 left the text card too
+// narrow, so the switch is set at 1366 where the card has more room. A
+// container-width threshold cannot separate the close cases reliably: 1024 with
+// the sidebar closed (~906px container) and 1280 with the sidebar open (~922px)
+// are only ~16px apart. The container is still measured with a ResizeObserver to
+// size the player and card, and must clear a floor (the `md` breakpoint, 768px)
+// so two columns never render in a container too narrow to hold them.
+const HERO_DESKTOP_MIN_VIEWPORT = 1366;
+const HERO_CONTAINER_MIN_WIDTH = 768;
+const HERO_GAP_PX = 26;
+const HERO_CARD_MIN_WIDTH_PX = 320;
+const HERO_CARD_MAX_WIDTH_PX = 466;
+const HERO_CARD_WIDTH_RATIO = 0.36;
+const HERO_HEIGHT_MIN_PX = 300;
+const HERO_HEIGHT_MAX_PX = 440;
+const HERO_PLAYER_ASPECT = 9 / 16;
 const HERO_LAYOUT = 'flex w-full flex-col gap-6';
 const HERO_LAYOUT_DESKTOP = 'flex-row items-start gap-[26px]';
 const PLAYER_AREA = 'w-full min-w-0';
 const PLAYER_AREA_DESKTOP = 'flex-1';
 const PLAYER_FRAME = 'relative aspect-video w-full overflow-hidden rounded-[6px] bg-site-player-canvas';
-const PLAYER_FRAME_DESKTOP = 'h-[440px] aspect-auto';
+const PLAYER_FRAME_DESKTOP = 'aspect-auto';
 const PLAYER_CLASS = 'relative h-full w-full overflow-hidden rounded-[6px] bg-site-player-canvas';
-const CARD_AREA = 'w-full min-w-0';
-const CARD_AREA_DESKTOP = 'h-[440px] w-[466px] shrink-0';
+// The card width is set via the computed inline style on desktop. Tailwind
+// utilities are generated with !important in this project, so `w-full` would
+// override that inline width and collapse the player. The card therefore takes
+// `w-full` only on mobile (CARD_AREA_MOBILE) and relies on the inline width plus
+// `shrink-0` on desktop.
+const CARD_AREA = 'min-w-0';
+const CARD_AREA_MOBILE = 'w-full';
+const CARD_AREA_DESKTOP = 'shrink-0';
+
+// Fluid two-column metrics. The card width scales with the container (clamped to
+// a 320-466px band) and the shared player/card height is derived from the
+// remaining player width at a 16:9 ratio (clamped to 300-440px). This keeps the
+// player at a correct aspect ratio at every desktop width instead of forcing a
+// fixed 440px height that squashes the video on narrower screens.
+function computeHeroDesktopMetrics(containerWidth) {
+	const cardWidth = Math.round(
+		Math.min(HERO_CARD_MAX_WIDTH_PX, Math.max(HERO_CARD_MIN_WIDTH_PX, containerWidth * HERO_CARD_WIDTH_RATIO))
+	);
+	const playerWidth = containerWidth - cardWidth - HERO_GAP_PX;
+	const height = Math.round(
+		Math.min(HERO_HEIGHT_MAX_PX, Math.max(HERO_HEIGHT_MIN_PX, playerWidth * HERO_PLAYER_ASPECT))
+	);
+	return { cardWidth, height };
+}
+
+function heroPlayerFrameStyle(metrics) {
+	// Fixed height keeps the player at a true 16:9 frame (the height is derived from
+	// the player width at a 9/16 ratio in computeHeroDesktopMetrics). The card uses
+	// the same value as a minHeight floor, so the two columns match while the player
+	// never letterboxes.
+	return metrics ? { height: metrics.height } : undefined;
+}
+
+function heroCardStyle(metrics) {
+	// The card width is fixed, but the height is a floor, not a cap. It matches the
+	// player height when the synopsis is short and grows past it when the text is
+	// longer, so the card never clips the description or the author/country/views
+	// block. The wrapper is a flex column and the card is flex-1 (see HeroMediaCard),
+	// which lets the card fill the floor yet expand to its content height.
+	return metrics ? { width: metrics.cardWidth, minHeight: metrics.height } : undefined;
+}
 
 class HeroPlayerErrorBoundary extends Component {
 	constructor(props) {
@@ -58,29 +115,41 @@ function useHeroMediaDetail(media) {
 
 function useHeroDesktopLayout() {
 	const rootRef = useRef(null);
-	const [isDesktopLayout, setIsDesktopLayout] = useState(false);
+	const [containerWidth, setContainerWidth] = useState(0);
+	const [viewportWidth, setViewportWidth] = useState(0);
 
 	useLayoutEffect(() => {
 		const root = rootRef.current;
 		if (!root) return undefined;
 
 		const updateLayout = () => {
-			setIsDesktopLayout(root.getBoundingClientRect().width >= HERO_DESKTOP_MIN_WIDTH);
+			setContainerWidth(root.getBoundingClientRect().width);
+			setViewportWidth(window.innerWidth);
 		};
 
 		updateLayout();
 
+		let resizeObserver;
 		if ('undefined' !== typeof ResizeObserver) {
-			const resizeObserver = new ResizeObserver(updateLayout);
+			resizeObserver = new ResizeObserver(updateLayout);
 			resizeObserver.observe(root);
-			return () => resizeObserver.disconnect();
 		}
-
 		window.addEventListener('resize', updateLayout);
-		return () => window.removeEventListener('resize', updateLayout);
+		return () => {
+			if (resizeObserver) {
+				resizeObserver.disconnect();
+			}
+			window.removeEventListener('resize', updateLayout);
+		};
 	}, []);
 
-	return { rootRef, isDesktopLayout };
+	const isDesktopLayout = viewportWidth >= HERO_DESKTOP_MIN_VIEWPORT && containerWidth >= HERO_CONTAINER_MIN_WIDTH;
+	const desktopMetrics = useMemo(
+		() => (isDesktopLayout ? computeHeroDesktopMetrics(containerWidth) : null),
+		[isDesktopLayout, containerWidth]
+	);
+
+	return { rootRef, isDesktopLayout, desktopMetrics };
 }
 
 function PlayAffordance() {
@@ -146,11 +215,14 @@ function Player() {
 	const playerKey = playback.sources[0]?.src ?? poster ?? media?.friendly_token;
 
 	if (!ctx || !media) return null;
-	const { isDesktopLayout, isHeroDetailError, retryHeroDetail } = ctx;
+	const { isDesktopLayout, desktopMetrics, isHeroDetailError, retryHeroDetail } = ctx;
 
 	return (
 		<div className={cn(PLAYER_AREA, isDesktopLayout ? PLAYER_AREA_DESKTOP : '')}>
-			<div className={cn(PLAYER_FRAME, isDesktopLayout ? PLAYER_FRAME_DESKTOP : '')}>
+			<div
+				className={cn(PLAYER_FRAME, isDesktopLayout ? PLAYER_FRAME_DESKTOP : '')}
+				style={heroPlayerFrameStyle(desktopMetrics)}
+			>
 				{playback.sources.length ? (
 					<HeroPlayerErrorBoundary fallback={<HeroPosterFallback src={poster} />} key={playerKey}>
 						<HeroVideoPlayer
@@ -187,14 +259,21 @@ function Player() {
 function Card() {
 	const ctx = use(HeroContext);
 	if (!ctx) return null;
-	const { media, isDesktopLayout } = ctx;
+	const { media, isDesktopLayout, desktopMetrics } = ctx;
 
-	return <HeroMediaCard media={media} className={cn(CARD_AREA, isDesktopLayout ? CARD_AREA_DESKTOP : '')} />;
+	return (
+		<HeroMediaCard
+			media={media}
+			isDesktop={isDesktopLayout}
+			className={cn(CARD_AREA, isDesktopLayout ? CARD_AREA_DESKTOP : CARD_AREA_MOBILE)}
+			style={heroCardStyle(desktopMetrics)}
+		/>
+	);
 }
 
 export function HeroSection({ children }) {
 	const { data, isLoading, isError, refetch } = useFeaturedMedia();
-	const { rootRef, isDesktopLayout } = useHeroDesktopLayout();
+	const { rootRef, isDesktopLayout, desktopMetrics } = useHeroDesktopLayout();
 
 	const items = normalizeMediaList(data);
 	const listMedia = items[0] ?? null;
@@ -208,8 +287,8 @@ export function HeroSection({ children }) {
 	}, [media?.thumbnail_url]);
 
 	const value = useMemo(
-		() => ({ media, isDesktopLayout, isHeroDetailError, retryHeroDetail }),
-		[media, isDesktopLayout, isHeroDetailError, retryHeroDetail]
+		() => ({ media, isDesktopLayout, desktopMetrics, isHeroDetailError, retryHeroDetail }),
+		[media, isDesktopLayout, desktopMetrics, isHeroDetailError, retryHeroDetail]
 	);
 
 	if (isError && !media) {
@@ -220,7 +299,10 @@ export function HeroSection({ children }) {
 					aria-label="Featured media"
 				>
 					<div className={cn(PLAYER_AREA, isDesktopLayout ? PLAYER_AREA_DESKTOP : '')}>
-						<div className={cn(PLAYER_FRAME, isDesktopLayout ? PLAYER_FRAME_DESKTOP : '')}>
+						<div
+							className={cn(PLAYER_FRAME, isDesktopLayout ? PLAYER_FRAME_DESKTOP : '')}
+							style={heroPlayerFrameStyle(desktopMetrics)}
+						>
 							<div className="flex h-full w-full items-center justify-center">
 								<button
 									type="button"
@@ -232,7 +314,10 @@ export function HeroSection({ children }) {
 							</div>
 						</div>
 					</div>
-					<HeroMediaCardSkeleton className={cn(CARD_AREA, isDesktopLayout ? CARD_AREA_DESKTOP : '')} />
+					<HeroMediaCardSkeleton
+						className={cn(CARD_AREA, isDesktopLayout ? CARD_AREA_DESKTOP : CARD_AREA_MOBILE)}
+						style={heroCardStyle(desktopMetrics)}
+					/>
 				</section>
 			</div>
 		);
@@ -257,8 +342,12 @@ export function HeroSection({ children }) {
 							'aspect-video rounded-[6px] bg-bg-skeleton animate-pulse',
 							isDesktopLayout ? `${PLAYER_AREA_DESKTOP} ${PLAYER_FRAME_DESKTOP}` : ''
 						)}
+						style={heroPlayerFrameStyle(desktopMetrics)}
 					/>
-					<HeroMediaCardSkeleton className={cn(CARD_AREA, isDesktopLayout ? CARD_AREA_DESKTOP : '')} />
+					<HeroMediaCardSkeleton
+						className={cn(CARD_AREA, isDesktopLayout ? CARD_AREA_DESKTOP : CARD_AREA_MOBILE)}
+						style={heroCardStyle(desktopMetrics)}
+					/>
 				</div>
 			</div>
 		);

--- a/frontend/src/features/home/components/HeroSection.test.jsx
+++ b/frontend/src/features/home/components/HeroSection.test.jsx
@@ -43,6 +43,7 @@ const SAMPLE_MEDIA = {
 };
 
 const originalResizeObserver = window.ResizeObserver;
+const originalInnerWidth = window.innerWidth;
 
 function makeClient(seededData) {
 	const client = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: 60_000 } } });
@@ -68,10 +69,23 @@ describe('HeroSection', () => {
 			writable: true,
 			value: originalResizeObserver,
 		});
+		Object.defineProperty(window, 'innerWidth', {
+			configurable: true,
+			writable: true,
+			value: originalInnerWidth,
+		});
 		vi.restoreAllMocks();
 	});
 
 	function mockHeroWidth(width) {
+		// Two-column layout requires both a desktop viewport and a container that
+		// clears the floor, so mock the viewport alongside the container width.
+		Object.defineProperty(window, 'innerWidth', {
+			configurable: true,
+			writable: true,
+			value: Math.max(width, 1366),
+		});
+
 		vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
 			bottom: 0,
 			height: 0,
@@ -154,11 +168,15 @@ describe('HeroSection', () => {
 		await waitFor(() => expect(region).toHaveClass('flex-row'));
 
 		const player = screen.getByTestId('hero-video-player');
-		expect(player.parentElement).toHaveClass('h-[440px]');
 		expect(player.parentElement).toHaveClass('aspect-auto');
+		// The player frame keeps a fixed 16:9 height; the card uses the same value as a
+		// minHeight floor so the two columns match without the player letterboxing.
+		expect(player.parentElement).toHaveStyle({ height: '440px' });
 		expect(player.parentElement.parentElement).toHaveClass('flex-1');
-		expect(screen.getByRole('article').parentElement).toHaveClass('w-[466px]');
-		expect(screen.getByRole('article').parentElement).toHaveClass('h-[440px]');
+		expect(screen.getByRole('article').parentElement).toHaveClass('shrink-0');
+		// The card width is fixed; its height is a floor (minHeight), so the card
+		// grows past the player height when the synopsis is long instead of clipping.
+		expect(screen.getByRole('article').parentElement).toHaveStyle({ width: '466px', minHeight: '440px' });
 	});
 
 	it('uses the light mode Figma color mapping for the metadata card', () => {


### PR DESCRIPTION
## Description
The two-column home hero card locked its height to the player and clipped the description with `max-h-[280px] overflow-hidden`. A long summary pushed the author/country/views block past the clipped edge, so the location was cut off. This change makes the card height a floor instead of a cap, removes the description clamp, and pins the meta block to the card bottom.

Specific changes:
- The card height is now `minHeight` (a floor) instead of a fixed `height`. The card matches the player height when the summary is short and grows past it when the summary is long, so the meta block is never clipped.
- The description clamp (`max-h-[280px] overflow-hidden`) is removed; the full summary always renders.
- The card uses `justify-between` with a `gap-4` minimum. When the summary leaves spare height the meta block is pinned to the card bottom; when the summary is long the groups sit at the 16px gap and the card grows without clipping.
- The player frame keeps a fixed 16:9 height (no letterboxing). The row is `items-start`, the card wrapper is a flex column, and the card is `flex-1` so it fills the floor.

## Related Issue
N/A

## Motivation and Context
On laptop and desktop widths the featured media synopsis card cut off the country/views line when the summary was long, and left the meta block floating with empty space below it when the summary was short. The card height and the player aspect ratio also fought each other (an earlier attempt letterboxed the player). This restores a true 16:9 player and makes the card adapt to its content.

## How Has This Been Tested?
- `npx vitest run src/features/home` from `frontend/`: 135 tests pass.
- Manual verification in the browser at multiple viewport widths:
  - 1366 (narrow card, long summary): player 348px at 16:9, card grows to 378px, location row fully visible, no clipping, no horizontal overflow.
  - 1680 (wide card, spare height): player and card both 440px, meta block pinned flush to the card bottom.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced responsive layout calculations for the hero section and media cards, improving sizing behavior across all screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->