### PR TITLE
fix(home): prevent mobile carousel dot overflow and align card badge/duration

### DIFF
--- a/frontend/src/features/home/components/Carousel.jsx
+++ b/frontend/src/features/home/components/Carousel.jsx
@@ -318,28 +318,68 @@ function CarouselOverlayArrows() {
 	);
 }
 
+// Cap how many page dots render at once so a long playlist (up to 20 pages on
+// mobile, where one item fills the viewport) cannot overflow the screen. The
+// window slides to keep the active page centered; boundary dots shrink to
+// signal that more pages exist beyond the visible range.
+const MAX_VISIBLE_DOTS = 7;
+
+function getDotWindow(count, activeIndex, maxVisible) {
+	if (count <= maxVisible) {
+		return { start: 0, end: count - 1 };
+	}
+	const half = Math.floor(maxVisible / 2);
+	let start = activeIndex - half;
+	let end = activeIndex + half;
+	if (start < 0) {
+		end -= start;
+		start = 0;
+	}
+	if (end > count - 1) {
+		start -= end - (count - 1);
+		end = count - 1;
+	}
+	return { start: Math.max(0, start), end };
+}
+
 function CarouselIndicator({ count, activeIndex, onSelect }) {
+	const { start, end } = getDotWindow(count, activeIndex, MAX_VISIBLE_DOTS);
+	const indices = [];
+	for (let i = start; i <= end; i += 1) {
+		indices.push(i);
+	}
+
 	return (
 		<div className="flex items-center gap-2" role="group" aria-label="Page navigation">
-			{Array.from({ length: count }, (_, i) => (
-				<button
-					key={i}
-					type="button"
-					onClick={() => onSelect(i)}
-					aria-label={`Go to page ${i + 1}`}
-					aria-current={i === activeIndex ? 'true' : undefined}
-					className="inline-flex size-6 min-w-6 items-center justify-center rounded-full border-0 bg-transparent p-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg-page"
-				>
-					<span
-						aria-hidden="true"
-						className={`rounded-full transition-[width,background-color] duration-300 ${
-							i === activeIndex
-								? 'h-2 w-6 bg-bg-primary'
-								: 'size-2 bg-border-strong/30 hover:bg-border-strong/50'
-						}`}
-					/>
-				</button>
-			))}
+			{indices.map((i) => {
+				const isActive = i === activeIndex;
+				const isEdge = !isActive && ((i === start && start > 0) || (i === end && end < count - 1));
+
+				let dotClass;
+				if (isActive) {
+					dotClass = 'h-2 w-6 bg-bg-primary';
+				} else if (isEdge) {
+					dotClass = 'size-1.5 bg-border-strong/30 hover:bg-border-strong/50';
+				} else {
+					dotClass = 'size-2 bg-border-strong/30 hover:bg-border-strong/50';
+				}
+
+				return (
+					<button
+						key={i}
+						type="button"
+						onClick={() => onSelect(i)}
+						aria-label={`Go to page ${i + 1}`}
+						aria-current={isActive ? 'true' : undefined}
+						className="inline-flex size-6 min-w-6 items-center justify-center rounded-full border-0 bg-transparent p-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg-page"
+					>
+						<span
+							aria-hidden="true"
+							className={`rounded-full transition-[width,background-color] duration-300 ${dotClass}`}
+						/>
+					</button>
+				);
+			})}
 		</div>
 	);
 }

--- a/frontend/src/features/home/components/Carousel.test.jsx
+++ b/frontend/src/features/home/components/Carousel.test.jsx
@@ -158,6 +158,33 @@ describe('Carousel — default shape', () => {
 		expect(dot.firstElementChild).toHaveClass('size-2');
 	});
 
+	it('caps page dots at seven so many pages cannot overflow the row', () => {
+		render(<Carousel items={makeItems(20)} visibleCount={1} />);
+
+		const dots = screen.getAllByRole('button', { name: /^Go to page \d+$/ });
+		expect(dots).toHaveLength(7);
+		expect(screen.getByRole('button', { name: 'Go to page 1' })).toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: 'Go to page 8' })).toBeNull();
+	});
+
+	it('shrinks the boundary dot when more pages exist beyond the window', () => {
+		render(<Carousel items={makeItems(20)} visibleCount={1} />);
+
+		const trailingEdge = screen.getByRole('button', { name: 'Go to page 7' });
+		expect(trailingEdge.firstElementChild).toHaveClass('size-1.5');
+	});
+
+	it('slides the dot window to keep the active page in view', async () => {
+		const user = userEvent.setup();
+		render(<Carousel items={makeItems(20)} visibleCount={1} />);
+
+		await user.click(screen.getByRole('button', { name: 'Go to page 7' }));
+
+		expect(screen.getByRole('button', { name: 'Go to page 7' })).toHaveAttribute('aria-current', 'true');
+		expect(screen.getByRole('button', { name: 'Go to page 10' })).toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: 'Go to page 1' })).toBeNull();
+	});
+
 	it('defaults to one visible item on phone viewports', () => {
 		mockViewportWidth(390);
 		render(<Carousel items={makeItems(4)} />);

--- a/frontend/src/features/shared/components/MovieItem/MovieItem.jsx
+++ b/frontend/src/features/shared/components/MovieItem/MovieItem.jsx
@@ -121,19 +121,23 @@ function MoviePoster({
 				decoding="async"
 			/>
 
-			{badge ? (
-				<Badge color={badgeColor} className="absolute bottom-3 left-3" data-movie-item-badge>
-					{badge}
-				</Badge>
-			) : null}
+			{badge || duration ? (
+				<div className="absolute inset-x-2 bottom-2 flex items-center gap-2">
+					{badge ? (
+						<Badge color={badgeColor} data-movie-item-badge>
+							{badge}
+						</Badge>
+					) : null}
 
-			{duration ? (
-				<span
-					className="absolute right-1 bottom-1 inline-flex rounded-[2px] bg-bg-overlay-dark px-1 py-[2px] font-sans text-[12px] font-medium leading-[13.5px] tracking-[0.5px] text-text-on-chrome"
-					data-movie-item-duration
-				>
-					{duration}
-				</span>
+					{duration ? (
+						<span
+							className="ml-auto inline-flex rounded-[2px] bg-bg-overlay-dark px-1 py-[2px] font-sans text-[12px] font-medium leading-[13.5px] tracking-[0.5px] text-text-on-chrome"
+							data-movie-item-duration
+						>
+							{duration}
+						</span>
+					) : null}
+				</div>
 			) : null}
 
 			{showTopRightIcon && iconName ? (

--- a/frontend/src/features/shared/components/MovieItem/MovieItem.test.jsx
+++ b/frontend/src/features/shared/components/MovieItem/MovieItem.test.jsx
@@ -25,8 +25,10 @@ describe('MovieItem', () => {
 		expect(screen.getByText('PG-13')).toBeVisible();
 		expect(screen.getByText('4K')).toBeVisible();
 		expect(screen.getByText('Premiere')).toBeVisible();
-		expect(screen.getByText('2h 3m')).toHaveClass('right-1');
-		expect(screen.getByText('2h 3m')).toHaveClass('bottom-1');
+		// Badge and duration share one bottom row; duration is pushed to the right edge with ml-auto.
+		expect(screen.getByText('2h 3m')).toHaveClass('ml-auto');
+		expect(screen.getByText('2h 3m').closest('div')).toHaveClass('inset-x-2');
+		expect(screen.getByText('2h 3m').closest('div')).toHaveClass('bottom-2');
 		expect(screen.getByText('2h 3m')).toHaveClass('text-[12px]');
 		expect(screen.getByText('2h 3m')).toHaveClass('leading-[13.5px]');
 		expect(screen.getByText('2h 3m')).toHaveClass('tracking-[0.5px]');


### PR DESCRIPTION
## Description
Two mobile UI fixes for the home page revamp.

1. Carousel pagination dots overflow on mobile. On mobile the carousel shows one item per page, so a 20-item playlist produced 20 page dots. Each dot is a 24px tap-target button, so the row exceeded the viewport width and overflowed the screen. The visible dots are now capped at seven using a sliding window centered on the active page. Boundary dots shrink to indicate that more pages exist. All pages remain reachable by swiping the track or by clicking a boundary dot to shift the window.

2. Media card badge and duration alignment. The category badge and the duration timestamp were two separate overlays at different vertical offsets, so they sat on different lines. They are now wrapped in a single flex row anchored at `inset-x-2 bottom-2`. The badge stays on the left and the duration is pushed to the right with `ml-auto`, so they align on one horizontal line.

## Related Issue
None.

## Motivation and Context
The pagination dots extended past the screen edge on narrow viewports, which broke the layout. The card category badge and duration timestamp were on separate lines and looked inconsistent. Both are visual defects in the home page revamp.

## How Has This Been Tested?
Vitest unit tests in `frontend`:
- `Carousel.test.jsx`: added three tests covering the dot cap (seven maximum), boundary dot shrinking, and window sliding on navigation.
- `MovieItem.test.jsx`: updated the duration overlay assertions to the new single-row layout.
- `MediaTile.test.jsx`: existing duration attribute tests still pass.

All carousel, MovieItem, MediaTile, SectionRow, and contract tests pass.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)
