### PR TITLE
Add application metrics and tracing instrumentation

### DIFF
--- a/cms/celery.py
+++ b/cms/celery.py
@@ -2,6 +2,8 @@ import os
 
 from celery import Celery
 
+from cms.observability import configure_celery_observability
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cms.settings")
 app = Celery("cms")
 
@@ -13,6 +15,8 @@ app.conf.broker_transport_options = {"visibility_timeout": 60 * 60 * 24}  # 1 da
 
 
 app.conf.worker_prefetch_multiplier = 1
+
+configure_celery_observability()
 
 
 @app.task(bind=True)

--- a/cms/observability.py
+++ b/cms/observability.py
@@ -1,0 +1,166 @@
+import logging
+from contextlib import contextmanager
+from typing import Any
+
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+_tracer_configured = False
+_django_instrumented = False
+_celery_instrumented = False
+_redis_instrumented = False
+_psycopg2_instrumented = False
+
+
+def observability_enabled() -> bool:
+    return bool(getattr(settings, "OTEL_ENABLED", False))
+
+
+def _parse_otlp_headers(value: str | dict[str, str] | None) -> dict[str, str] | None:
+    if not value:
+        return None
+    if isinstance(value, dict):
+        return value
+
+    headers = {}
+    for item in value.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        key, sep, header_value = item.partition("=")
+        if sep:
+            headers[key.strip()] = header_value.strip()
+    return headers or None
+
+
+def _configure_tracer_provider() -> bool:
+    global _tracer_configured
+
+    if _tracer_configured:
+        return True
+    if not observability_enabled():
+        return False
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+        from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+        from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
+    except ImportError:
+        logger.exception("OpenTelemetry packages are not installed")
+        return False
+
+    resource = Resource.create({SERVICE_NAME: getattr(settings, "OTEL_SERVICE_NAME", "cinematacms")})
+    sampler = TraceIdRatioBased(float(getattr(settings, "OTEL_TRACES_SAMPLER_ARG", 1.0)))
+    provider = TracerProvider(resource=resource, sampler=sampler)
+    exporter = OTLPSpanExporter(
+        endpoint=getattr(settings, "OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:4318/v1/traces"),
+        headers=_parse_otlp_headers(getattr(settings, "OTEL_EXPORTER_OTLP_HEADERS", "")),
+    )
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    _tracer_configured = True
+    return True
+
+
+def configure_django_observability() -> None:
+    global _django_instrumented, _redis_instrumented, _psycopg2_instrumented
+
+    if not _configure_tracer_provider():
+        return
+
+    try:
+        if not _django_instrumented:
+            from opentelemetry.instrumentation.django import DjangoInstrumentor
+
+            DjangoInstrumentor().instrument()
+            _django_instrumented = True
+        if not _redis_instrumented:
+            from opentelemetry.instrumentation.redis import RedisInstrumentor
+
+            RedisInstrumentor().instrument()
+            _redis_instrumented = True
+        if not _psycopg2_instrumented:
+            from opentelemetry.instrumentation.psycopg2 import Psycopg2Instrumentor
+
+            Psycopg2Instrumentor().instrument()
+            _psycopg2_instrumented = True
+    except Exception:
+        logger.exception("Failed to configure Django observability")
+
+
+def configure_celery_observability() -> None:
+    global _celery_instrumented
+
+    if not _configure_tracer_provider():
+        return
+
+    try:
+        if not _celery_instrumented:
+            from opentelemetry.instrumentation.celery import CeleryInstrumentor
+
+            CeleryInstrumentor().instrument()
+            _celery_instrumented = True
+    except Exception:
+        logger.exception("Failed to configure Celery observability")
+
+
+def inject_trace_headers(headers: dict[str, Any] | None = None) -> dict[str, Any]:
+    merged = dict(headers or {})
+    if not observability_enabled():
+        return merged
+    try:
+        from opentelemetry.propagate import inject
+
+        inject(merged)
+    except Exception:
+        logger.debug("Failed to inject trace headers", exc_info=True)
+    return merged
+
+
+def current_trace_ids() -> tuple[str, str]:
+    if not observability_enabled():
+        return "", ""
+    try:
+        from opentelemetry import trace
+
+        context = trace.get_current_span().get_span_context()
+        if not context or not context.is_valid:
+            return "", ""
+        return f"{context.trace_id:032x}", f"{context.span_id:016x}"
+    except Exception:
+        return "", ""
+
+
+class OpenTelemetryLogFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        trace_id, span_id = current_trace_ids()
+        record.trace_id = trace_id
+        record.span_id = span_id
+        return True
+
+
+def get_tracer(name: str):
+    try:
+        from opentelemetry import trace
+
+        return trace.get_tracer(name)
+    except Exception:
+        return None
+
+
+@contextmanager
+def start_span(name: str, attributes: dict[str, Any] | None = None):
+    tracer = get_tracer("cinematacms")
+    if not observability_enabled() or tracer is None:
+        yield None
+        return
+    with tracer.start_as_current_span(name) as span:
+        if attributes:
+            for key, value in attributes.items():
+                if value is not None:
+                    span.set_attribute(key, value)
+        yield span

--- a/cms/observability_middleware.py
+++ b/cms/observability_middleware.py
@@ -1,0 +1,58 @@
+import time
+
+from django.conf import settings
+from django.db import connection
+
+from files.metrics import (
+    HTTP_REQUEST_DURATION_SECONDS,
+    HTTP_REQUESTS_TOTAL,
+    SLOW_DB_QUERIES_TOTAL,
+    SLOW_REQUESTS_TOTAL,
+    classify_endpoint_group,
+)
+
+
+class ObservabilityMetricsMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        start = time.monotonic()
+        endpoint_group = classify_endpoint_group(request.path)
+        slow_query_count = 0
+
+        def execute_wrapper(execute, sql, params, many, context):
+            nonlocal slow_query_count
+            query_start = time.monotonic()
+            try:
+                return execute(sql, params, many, context)
+            finally:
+                duration = time.monotonic() - query_start
+                if duration >= getattr(settings, "OBSERVABILITY_SLOW_QUERY_SECONDS", 1.0):
+                    slow_query_count += 1
+
+        try:
+            with connection.execute_wrapper(execute_wrapper):
+                response = self.get_response(request)
+        except Exception:
+            duration = time.monotonic() - start
+            self._record(request, endpoint_group, 500, duration, slow_query_count)
+            raise
+
+        duration = time.monotonic() - start
+        self._record(request, endpoint_group, response.status_code, duration, slow_query_count)
+        return response
+
+    def _record(self, request, endpoint_group, status_code, duration, slow_query_count):
+        method = request.method.upper()
+        status_class = f"{status_code // 100}xx"
+        HTTP_REQUESTS_TOTAL.labels(endpoint_group=endpoint_group, method=method, status_class=status_class).inc()
+        HTTP_REQUEST_DURATION_SECONDS.labels(
+            endpoint_group=endpoint_group,
+            method=method,
+            status_class=status_class,
+        ).observe(duration)
+        if duration >= getattr(settings, "OBSERVABILITY_SLOW_REQUEST_SECONDS", 2.0):
+            SLOW_REQUESTS_TOTAL.labels(endpoint_group=endpoint_group, method=method).inc()
+        if slow_query_count:
+            SLOW_DB_QUERIES_TOTAL.labels(endpoint_group=endpoint_group).inc(slow_query_count)

--- a/cms/settings.py
+++ b/cms/settings.py
@@ -81,6 +81,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django_prometheus.middleware.PrometheusBeforeMiddleware",
+    "cms.observability_middleware.ObservabilityMetricsMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -155,13 +156,29 @@ FILE_UPLOAD_HANDLERS = [
 
 LOGS_DIR = os.path.join(BASE_DIR, "logs")
 
+# Observability settings are intentionally defined here, not read from .env.
+# Production currently manages runtime configuration through settings.py.
+OTEL_ENABLED = False
+OTEL_SERVICE_NAME = "cinematacms"
+OTEL_EXPORTER_OTLP_ENDPOINT = "http://127.0.0.1:4318/v1/traces"
+OTEL_EXPORTER_OTLP_HEADERS = ""
+OTEL_TRACES_SAMPLER_ARG = 1.0
+OBSERVABILITY_CELERY_QUEUES = ["long_tasks", "short_tasks", "whisper_tasks"]
+OBSERVABILITY_SLOW_REQUEST_SECONDS = 2.0
+OBSERVABILITY_SLOW_QUERY_SECONDS = 1.0
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
+    "filters": {
+        "otel_trace": {
+            "()": "cms.observability.OpenTelemetryLogFilter",
+        },
+    },
     "formatters": {
         "json": {
             "()": "pythonjsonlogger.json.JsonFormatter",
-            "format": "%(asctime)s %(name)s %(levelname)s %(message)s",
+            "format": "%(asctime)s %(name)s %(levelname)s %(message)s %(trace_id)s %(span_id)s",
             "rename_fields": {
                 "asctime": "timestamp",
                 "levelname": "level",
@@ -180,12 +197,14 @@ LOGGING = {
             "class": "logging.FileHandler",
             "filename": os.path.join(LOGS_DIR, "app.json.log"),
             "formatter": "json",
+            "filters": ["otel_trace"],
         },
         "legacy_file": {
             "level": "INFO",
             "class": "logging.FileHandler",
             "filename": os.path.join(LOGS_DIR, "debug.log"),
             "formatter": "plain",
+            "filters": ["otel_trace"],
         },
     },
     "loggers": {

--- a/cms/tests/test_observability.py
+++ b/cms/tests/test_observability.py
@@ -1,0 +1,215 @@
+import logging
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import Mock, call, patch
+
+from django.http import HttpResponse
+from django.test import RequestFactory, SimpleTestCase, override_settings
+
+from cms.observability import OpenTelemetryLogFilter, inject_trace_headers
+from cms.observability_middleware import ObservabilityMetricsMiddleware
+from cms.urls import metrics_view
+from files.metrics import classify_endpoint_group
+
+
+class ObservabilityConfigTests(SimpleTestCase):
+    @override_settings(OTEL_ENABLED=False)
+    def test_trace_header_injection_is_noop_when_disabled(self):
+        headers = inject_trace_headers({"enqueued_at": 123})
+        self.assertEqual(headers, {"enqueued_at": 123})
+
+    @override_settings(OTEL_ENABLED=False)
+    def test_log_filter_adds_empty_trace_fields_when_disabled(self):
+        record = logging.LogRecord("test", logging.INFO, __file__, 1, "msg", (), None)
+        self.assertTrue(OpenTelemetryLogFilter().filter(record))
+        self.assertEqual(record.trace_id, "")
+        self.assertEqual(record.span_id, "")
+
+
+class EndpointGroupingTests(SimpleTestCase):
+    def test_endpoint_grouping_uses_low_cardinality_labels(self):
+        cases = {
+            "/metrics": "system",
+            "/health/ready": "system",
+            "/api/v1/search?q=abc": "api_search",
+            "/api/v1/media/abc123": "api_media",
+            "/api/v1/manage_media": "api_manage",
+            "/manage/media": "api_manage",
+            "/fu/upload/": "uploads",
+            "/upload": "uploads",
+            "/media/original/video.mp4": "media_serve",
+            "/api/v1/users": "api_other",
+            "/some-page": "pages",
+        }
+        for path, expected in cases.items():
+            with self.subTest(path=path):
+                self.assertEqual(classify_endpoint_group(path), expected)
+
+
+class ObservabilityMiddlewareTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    @contextmanager
+    def _fake_execute_wrapper(self):
+        yield
+
+    @override_settings(OBSERVABILITY_SLOW_REQUEST_SECONDS=0)
+    def test_middleware_records_request_without_raw_path_label(self):
+        request = self.factory.get("/api/v1/media/sensitive-token")
+        response = HttpResponse("ok", status=201)
+
+        with (
+            patch("cms.observability_middleware.connection.execute_wrapper", return_value=self._fake_execute_wrapper()),
+            patch("cms.observability_middleware.HTTP_REQUESTS_TOTAL") as requests_total,
+            patch("cms.observability_middleware.HTTP_REQUEST_DURATION_SECONDS") as duration,
+            patch("cms.observability_middleware.SLOW_REQUESTS_TOTAL") as slow_requests,
+        ):
+            requests_total.labels.return_value.inc = Mock()
+            duration.labels.return_value.observe = Mock()
+            slow_requests.labels.return_value.inc = Mock()
+
+            result = ObservabilityMetricsMiddleware(lambda _request: response)(request)
+
+        self.assertIs(result, response)
+        requests_total.labels.assert_called_once_with(endpoint_group="api_media", method="GET", status_class="2xx")
+        duration.labels.assert_called_once_with(endpoint_group="api_media", method="GET", status_class="2xx")
+        slow_requests.labels.assert_called_once_with(endpoint_group="api_media", method="GET")
+
+
+class MetricsViewTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_metrics_view_refreshes_runtime_metrics_for_localhost(self):
+        request = self.factory.get("/metrics", REMOTE_ADDR="127.0.0.1")
+        with (
+            patch("cms.urls.refresh_runtime_metrics") as refresh,
+            patch("cms.urls.generate_latest", return_value=b"metric 1\n"),
+        ):
+            response = metrics_view(request)
+
+        self.assertEqual(response.status_code, 200)
+        refresh.assert_called_once_with()
+        self.assertEqual(response.content, b"metric 1\n")
+
+    def test_metrics_view_forbids_external_anonymous_client(self):
+        request = self.factory.get("/metrics", REMOTE_ADDR="203.0.113.10")
+        with patch("cms.urls.refresh_runtime_metrics") as refresh:
+            response = metrics_view(request)
+
+        self.assertEqual(response.status_code, 403)
+        refresh.assert_not_called()
+
+
+class CacheMetricTests(SimpleTestCase):
+    def test_permission_cache_miss_is_recorded(self):
+        from files import cache_utils
+
+        with (
+            patch.object(cache_utils.cache, "get", return_value=None),
+            patch("files.cache_utils.record_cache_operation") as record,
+        ):
+            self.assertIsNone(cache_utils.get_cached_permission("permission-key"))
+
+        record.assert_called_once_with("permission", "get", hit=False)
+
+    def test_query_cache_hit_is_recorded(self):
+        from files import query_cache
+
+        with (
+            patch.object(query_cache.cache, "get", return_value={"ok": True}),
+            patch("files.query_cache.record_cache_operation") as record,
+        ):
+            self.assertEqual(query_cache.get_cached_result("query-key"), {"ok": True})
+
+        record.assert_called_once_with("query", "get", hit=True)
+
+
+class CeleryAndMediaMetricTests(SimpleTestCase):
+    def test_celery_task_signal_helpers_record_lifecycle(self):
+        from files import metrics
+
+        sender = SimpleNamespace(name="encode_media")
+        with (
+            patch("files.metrics.CELERY_TASKS_TOTAL") as task_total,
+            patch("files.metrics.CELERY_TASK_ACTIVE") as task_active,
+            patch("files.metrics.CELERY_TASK_DURATION_SECONDS") as duration,
+        ):
+            task_total.labels.return_value.inc = Mock()
+            task_active.labels.return_value.inc = Mock()
+            task_active.labels.return_value.dec = Mock()
+            duration.labels.return_value.observe = Mock()
+
+            metrics._task_start_times.clear()
+            metrics._on_task_prerun(sender=sender, task_id="task-1")
+            metrics._on_task_postrun(sender=sender, task_id="task-1", state="SUCCESS")
+
+        task_total.labels.assert_any_call(task_name="encode_media", state="started")
+        task_total.labels.assert_any_call(task_name="encode_media", state="success")
+        task_active.labels.assert_called_with(task_name="encode_media")
+        duration.labels.assert_called_once_with(task_name="encode_media")
+
+    def test_media_pipeline_observation_uses_low_cardinality_profile_labels(self):
+        from files.metrics import observe_media_pipeline
+
+        media = SimpleNamespace(media_type="video", duration=120, media_file=SimpleNamespace(size=123456))
+        profile = SimpleNamespace(resolution=720, codec="h264", extension="mp4")
+        with (
+            patch("files.metrics.MEDIA_ENCODING_PROFILE_TOTAL") as profile_total,
+            patch("files.metrics.MEDIA_DURATION_SECONDS") as duration,
+            patch("files.metrics.MEDIA_FILE_SIZE_BYTES") as file_size,
+        ):
+            profile_total.labels.return_value.inc = Mock()
+            duration.labels.return_value.observe = Mock()
+            file_size.labels.return_value.observe = Mock()
+
+            observe_media_pipeline(media, profile, "success")
+
+        profile_total.labels.assert_called_once_with(
+            resolution="720",
+            codec="h264",
+            extension="mp4",
+            status="success",
+        )
+        duration.labels.assert_called_once_with(media_type="video")
+        duration.labels.return_value.observe.assert_called_once_with(120)
+        file_size.labels.assert_called_once_with(media_type="video")
+        file_size.labels.return_value.observe.assert_called_once_with(123456)
+
+    @override_settings(RUNNING_STATE_STALE=10)
+    def test_stalled_encoding_refresh_resets_disappeared_labelsets(self):
+        from files import metrics
+
+        metrics._stalled_encoding_label_values.clear()
+        metrics._stalled_encoding_label_values.add(("720", "h264", "mp4"))
+        encoding = SimpleNamespace(
+            update_date=datetime.fromtimestamp(80, tz=timezone.utc),
+            profile=SimpleNamespace(resolution=1080, codec="h265", extension="webm"),
+        )
+        queryset = Mock()
+        queryset.select_related.return_value = [encoding]
+
+        try:
+            with (
+                patch("files.models.Encoding") as Encoding,
+                patch("files.metrics.time.time", return_value=100),
+                patch("files.metrics.ENCODING_STALLED") as stalled,
+            ):
+                stalled.labels.return_value.set = Mock()
+                Encoding.objects.filter.return_value = queryset
+
+                metrics._refresh_stalled_encodings()
+
+            stalled.labels.assert_has_calls(
+                [
+                    call(resolution="1080", codec="h265", extension="webm"),
+                    call(resolution="720", codec="h264", extension="mp4"),
+                ],
+                any_order=True,
+            )
+            stalled.labels.return_value.set.assert_has_calls([call(1), call(0)], any_order=True)
+            self.assertEqual(metrics._stalled_encoding_label_values, {("1080", "h265", "webm")})
+        finally:
+            metrics._stalled_encoding_label_values.clear()

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -11,6 +11,7 @@ from prometheus_client import multiprocess as prom_multiprocess
 from cms.health import live as health_live
 from cms.health import ready as health_ready
 from cms.request_utils import get_client_ip
+from files.metrics import refresh_runtime_metrics
 
 
 def metrics_view(request):
@@ -23,6 +24,8 @@ def metrics_view(request):
         from django.http import HttpResponseForbidden
 
         return HttpResponseForbidden()
+
+    refresh_runtime_metrics()
 
     # Use multiprocess registry when PROMETHEUS_MULTIPROC_DIR is set (production),
     # fall back to default in-process registry (dev with CELERY_TASK_ALWAYS_EAGER)

--- a/cms/wsgi.py
+++ b/cms/wsgi.py
@@ -4,6 +4,10 @@ from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cms.settings")
 
+from cms.observability import configure_django_observability
+
+configure_django_observability()
+
 try:
     import uwsgi
     from prometheus_client.values import MultiProcessValue

--- a/files/apps.py
+++ b/files/apps.py
@@ -5,4 +5,4 @@ class FilesConfig(AppConfig):
     name = "files"
 
     def ready(self):
-        import files.metrics  # noqa: F401 — register Prometheus metrics at startup
+        import files.metrics  # noqa: F401 — register Prometheus metrics and signal handlers at startup

--- a/files/cache_utils.py
+++ b/files/cache_utils.py
@@ -24,6 +24,8 @@ from typing import Any
 from django.conf import settings
 from django.core.cache import cache
 
+from .metrics import record_cache_operation
+
 logger = logging.getLogger(__name__)
 
 # Cache configuration constants
@@ -97,9 +99,13 @@ def get_cached_permission(cache_key: str) -> bool | None:
         result = cache.get(cache_key, version=CACHE_VERSION)
         if result is not None:
             logger.debug(f"Cache hit for key: {cache_key}")
+            record_cache_operation("permission", "get", hit=True)
+        else:
+            record_cache_operation("permission", "get", hit=False)
         return result
     except Exception as e:
         logger.warning(f"Cache get failed for key {cache_key}: {e}")
+        record_cache_operation("permission", "get", ok=False)
         return None
 
 
@@ -121,9 +127,11 @@ def set_cached_permission(cache_key: str, permission_result: bool, timeout: int 
     try:
         cache.set(cache_key, permission_result, timeout, version=CACHE_VERSION)
         logger.debug(f"Cached permission result for key: {cache_key}")
+        record_cache_operation("permission", "set")
         return True
     except Exception as e:
         logger.warning(f"Cache set failed for key {cache_key}: {e}")
+        record_cache_operation("permission", "set", ok=False)
         return False
 
 
@@ -140,9 +148,11 @@ def batch_get_cached_permissions(cache_keys: list) -> dict[str, bool | None]:
     try:
         results = cache.get_many(cache_keys, version=CACHE_VERSION)
         logger.debug(f"Batch cache get: {len(results)}/{len(cache_keys)} hits")
+        record_cache_operation("permission", "get_many", hit=bool(results))
         return results
     except Exception as e:
         logger.warning(f"Batch cache get failed: {e}")
+        record_cache_operation("permission", "get_many", ok=False)
         return {}
 
 
@@ -163,9 +173,11 @@ def batch_set_cached_permissions(cache_data: dict[str, bool], timeout: int | Non
     try:
         cache.set_many(cache_data, timeout, version=CACHE_VERSION)
         logger.debug(f"Batch cache set: {len(cache_data)} entries")
+        record_cache_operation("permission", "set_many")
         return True
     except Exception as e:
         logger.warning(f"Batch cache set failed: {e}")
+        record_cache_operation("permission", "set_many", ok=False)
         return False
 
 

--- a/files/metrics.py
+++ b/files/metrics.py
@@ -1,7 +1,268 @@
-from prometheus_client import Histogram
+import logging
+import socket
+import time
+
+from celery.signals import task_postrun, task_prerun, worker_ready, worker_shutdown
+from django.conf import settings
+from django.contrib.auth.signals import user_login_failed
+from prometheus_client import Counter, Gauge, Histogram
+
+logger = logging.getLogger(__name__)
 
 ENCODING_QUEUE_WAIT_SECONDS = Histogram(
     "cinemata_encoding_queue_wait_seconds",
     "Time an encoding task waited in the Celery queue before execution",
     buckets=(1, 5, 10, 30, 60, 120, 300, 600, 1800, 3600),
 )
+
+HTTP_REQUESTS_TOTAL = Counter(
+    "cinemata_http_requests_total",
+    "HTTP requests grouped by stable endpoint class",
+    ["endpoint_group", "method", "status_class"],
+)
+HTTP_REQUEST_DURATION_SECONDS = Histogram(
+    "cinemata_http_request_duration_seconds",
+    "HTTP request duration grouped by stable endpoint class",
+    ["endpoint_group", "method", "status_class"],
+    buckets=(0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30),
+)
+SLOW_REQUESTS_TOTAL = Counter(
+    "cinemata_http_slow_requests_total",
+    "HTTP requests exceeding OBSERVABILITY_SLOW_REQUEST_SECONDS",
+    ["endpoint_group", "method"],
+)
+SLOW_DB_QUERIES_TOTAL = Counter(
+    "cinemata_db_slow_queries_total",
+    "Database queries exceeding OBSERVABILITY_SLOW_QUERY_SECONDS",
+    ["endpoint_group"],
+)
+AUTH_FAILURES_TOTAL = Counter(
+    "cinemata_auth_failures_total",
+    "Failed authentication attempts",
+    ["source"],
+)
+
+CELERY_TASKS_TOTAL = Counter(
+    "cinemata_celery_tasks_total",
+    "Celery task lifecycle events",
+    ["task_name", "state"],
+)
+CELERY_TASK_DURATION_SECONDS = Histogram(
+    "cinemata_celery_task_duration_seconds",
+    "Celery task duration by task name",
+    ["task_name"],
+    buckets=(0.1, 0.5, 1, 5, 15, 30, 60, 120, 300, 600, 1800, 3600, 7200),
+)
+CELERY_TASK_ACTIVE = Gauge(
+    "cinemata_celery_task_active",
+    "Currently running Celery tasks by task name",
+    ["task_name"],
+)
+CELERY_WORKER_UP = Gauge(
+    "cinemata_celery_worker_up",
+    "Celery worker process seen as ready",
+    ["worker"],
+)
+CELERY_QUEUE_DEPTH = Gauge(
+    "cinemata_celery_queue_depth",
+    "Redis broker queue length by queue name",
+    ["queue"],
+)
+
+MEDIA_ENCODING_PROFILE_TOTAL = Counter(
+    "cinemata_media_encoding_profile_total",
+    "Encoding completions by profile and result",
+    ["resolution", "codec", "extension", "status"],
+)
+MEDIA_FILE_SIZE_BYTES = Histogram(
+    "cinemata_media_file_size_bytes",
+    "Original media file size by media type",
+    ["media_type"],
+    buckets=(1_000_000, 10_000_000, 50_000_000, 100_000_000, 500_000_000, 1_000_000_000, 5_000_000_000),
+)
+MEDIA_DURATION_SECONDS = Histogram(
+    "cinemata_media_duration_seconds",
+    "Media duration by media type",
+    ["media_type"],
+    buckets=(30, 60, 300, 600, 1200, 1800, 3600, 7200, 14400),
+)
+TRANSCRIPTION_REQUESTS = Gauge(
+    "cinemata_transcription_requests",
+    "Current transcription request rows",
+    ["translate_to_english"],
+)
+ENCODING_STALE_TOTAL = Counter(
+    "cinemata_encoding_stale_total",
+    "Encoding rows considered stale and requeued",
+    ["resolution", "codec", "extension"],
+)
+ENCODING_STALLED = Gauge(
+    "cinemata_encoding_stalled",
+    "Current running encoding rows older than RUNNING_STATE_STALE",
+    ["resolution", "codec", "extension"],
+)
+CACHE_OPERATIONS_TOTAL = Counter(
+    "cinemata_cache_operations_total",
+    "Explicit project cache helper operations",
+    ["cache", "operation", "result"],
+)
+
+_task_start_times: dict[str, float] = {}
+_stalled_encoding_label_values: set[tuple[str, str, str]] = set()
+
+
+def classify_endpoint_group(path: str) -> str:
+    normalized = path.rstrip("/") or "/"
+    if normalized in {"/metrics", "/health/live", "/health/ready"}:
+        return "system"
+    if normalized.startswith("/api/v1/search"):
+        return "api_search"
+    if normalized.startswith("/api/v1/media"):
+        return "api_media"
+    if normalized.startswith("/api/v1/manage") or normalized.startswith("/manage"):
+        return "api_manage"
+    if normalized.startswith("/fu/") or normalized.startswith("/upload"):
+        return "uploads"
+    if normalized.startswith("/media/") or normalized.startswith("/internal/media/"):
+        return "media_serve"
+    if normalized.startswith("/api/"):
+        return "api_other"
+    return "pages"
+
+
+def _task_name(sender=None, task_id=None, **kwargs) -> str:
+    if sender is not None and getattr(sender, "name", None):
+        return str(sender.name)
+    task = kwargs.get("task")
+    if task is not None and getattr(task, "name", None):
+        return str(task.name)
+    return "unknown"
+
+
+def _on_task_prerun(sender=None, task_id=None, **kwargs):
+    name = _task_name(sender=sender, **kwargs)
+    if task_id:
+        _task_start_times[task_id] = time.monotonic()
+    CELERY_TASKS_TOTAL.labels(task_name=name, state="started").inc()
+    CELERY_TASK_ACTIVE.labels(task_name=name).inc()
+
+
+def _on_task_postrun(sender=None, task_id=None, state=None, **kwargs):
+    name = _task_name(sender=sender, **kwargs)
+    if task_id and task_id in _task_start_times:
+        CELERY_TASK_DURATION_SECONDS.labels(task_name=name).observe(time.monotonic() - _task_start_times.pop(task_id))
+    if state in {"SUCCESS", "FAILURE"}:
+        CELERY_TASKS_TOTAL.labels(task_name=name, state=state.lower()).inc()
+    CELERY_TASK_ACTIVE.labels(task_name=name).dec()
+
+
+def _worker_label(sender=None) -> str:
+    if sender is not None and getattr(sender, "hostname", None):
+        return str(sender.hostname)
+    return socket.gethostname()
+
+
+def _on_worker_ready(sender=None, **kwargs):
+    CELERY_WORKER_UP.labels(worker=_worker_label(sender)).set(1)
+
+
+def _on_worker_shutdown(sender=None, **kwargs):
+    CELERY_WORKER_UP.labels(worker=_worker_label(sender)).set(0)
+
+
+def _on_user_login_failed(sender=None, **kwargs):
+    AUTH_FAILURES_TOTAL.labels(source="django").inc()
+
+
+def connect_signal_handlers() -> None:
+    task_prerun.connect(_on_task_prerun, dispatch_uid="cinemata_metrics_task_prerun", weak=False)
+    task_postrun.connect(_on_task_postrun, dispatch_uid="cinemata_metrics_task_postrun", weak=False)
+    worker_ready.connect(_on_worker_ready, dispatch_uid="cinemata_metrics_worker_ready", weak=False)
+    worker_shutdown.connect(_on_worker_shutdown, dispatch_uid="cinemata_metrics_worker_shutdown", weak=False)
+    user_login_failed.connect(_on_user_login_failed, dispatch_uid="cinemata_metrics_login_failed", weak=False)
+
+
+def record_cache_operation(cache_name: str, operation: str, hit: bool | None = None, ok: bool = True) -> None:
+    if not ok:
+        result = "error"
+    elif hit is None:
+        result = "ok"
+    else:
+        result = "hit" if hit else "miss"
+    CACHE_OPERATIONS_TOTAL.labels(cache=cache_name, operation=operation, result=result).inc()
+
+
+def _profile_labels(profile) -> dict[str, str]:
+    return {
+        "resolution": str(getattr(profile, "resolution", None) or "unknown"),
+        "codec": str(getattr(profile, "codec", None) or "unknown"),
+        "extension": str(getattr(profile, "extension", None) or "unknown"),
+    }
+
+
+def observe_media_pipeline(media, profile, status: str) -> None:
+    MEDIA_ENCODING_PROFILE_TOTAL.labels(status=status, **_profile_labels(profile)).inc()
+    media_type = str(getattr(media, "media_type", None) or "unknown")
+    duration = getattr(media, "duration", 0) or 0
+    if duration > 0:
+        MEDIA_DURATION_SECONDS.labels(media_type=media_type).observe(duration)
+    try:
+        if getattr(media, "media_file", None):
+            MEDIA_FILE_SIZE_BYTES.labels(media_type=media_type).observe(media.media_file.size)
+    except Exception:
+        logger.debug("Could not observe media file size", exc_info=True)
+
+
+def record_stale_encoding(encoding) -> None:
+    ENCODING_STALE_TOTAL.labels(**_profile_labels(encoding.profile)).inc()
+
+
+def refresh_runtime_metrics() -> None:
+    _refresh_queue_depths()
+    _refresh_transcription_requests()
+    _refresh_stalled_encodings()
+
+
+def _refresh_queue_depths() -> None:
+    try:
+        from django_redis import get_redis_connection
+
+        connection = get_redis_connection("default")
+        for queue in getattr(settings, "OBSERVABILITY_CELERY_QUEUES", []):
+            CELERY_QUEUE_DEPTH.labels(queue=queue).set(connection.llen(queue))
+    except Exception:
+        logger.debug("Could not refresh Celery queue depth metrics", exc_info=True)
+
+
+def _refresh_transcription_requests() -> None:
+    try:
+        from files.models import TranscriptionRequest
+
+        for translate in (False, True):
+            count = TranscriptionRequest.objects.filter(translate_to_english=translate).count()
+            TRANSCRIPTION_REQUESTS.labels(translate_to_english=str(translate).lower()).set(count)
+    except Exception:
+        logger.debug("Could not refresh transcription request metrics", exc_info=True)
+
+
+def _refresh_stalled_encodings() -> None:
+    try:
+        from files.models import Encoding
+
+        threshold = time.time() - getattr(settings, "RUNNING_STATE_STALE", 7200)
+        by_profile = {}
+        for encoding in Encoding.objects.filter(status="running").select_related("profile"):
+            if encoding.update_date and encoding.update_date.timestamp() < threshold:
+                labels = tuple(_profile_labels(encoding.profile).values())
+                by_profile[labels] = by_profile.get(labels, 0) + 1
+        for (resolution, codec, extension), count in by_profile.items():
+            ENCODING_STALLED.labels(resolution=resolution, codec=codec, extension=extension).set(count)
+        for resolution, codec, extension in _stalled_encoding_label_values - set(by_profile):
+            ENCODING_STALLED.labels(resolution=resolution, codec=codec, extension=extension).set(0)
+        _stalled_encoding_label_values.clear()
+        _stalled_encoding_label_values.update(by_profile)
+    except Exception:
+        logger.debug("Could not refresh stalled encoding metrics", exc_info=True)
+
+
+connect_signal_handlers()

--- a/files/models.py
+++ b/files/models.py
@@ -35,6 +35,7 @@ from imagekit.models import ProcessedImageField
 from imagekit.processors import ResizeToFit
 from mptt.models import MPTTModel, TreeForeignKey
 
+from cms.observability import inject_trace_headers
 from users.validators import validate_internal_html
 
 from . import helpers, lists
@@ -577,9 +578,16 @@ class Media(models.Model):
             from . import tasks
 
             if can_transcribe:
-                tasks.whisper_transcribe.delay(self.friendly_token)
+                tasks.whisper_transcribe.apply_async(
+                    args=[self.friendly_token],
+                    headers=inject_trace_headers(),
+                )
             if can_transcribe_and_translate:
-                tasks.whisper_transcribe.delay(self.friendly_token, translate=True)
+                tasks.whisper_transcribe.apply_async(
+                    args=[self.friendly_token],
+                    kwargs={"translate": True},
+                    headers=inject_trace_headers(),
+                )
 
     def update_search_vector(self):
         """
@@ -771,7 +779,10 @@ class Media(models.Model):
     def produce_sprite_from_video(self):
         from . import tasks
 
-        tasks.produce_sprite_from_video.delay(self.friendly_token)
+        tasks.produce_sprite_from_video.apply_async(
+            args=[self.friendly_token],
+            headers=inject_trace_headers(),
+        )
         return True
 
     def _is_encoding_rate_limited(self):
@@ -837,7 +848,7 @@ class Media(models.Model):
                 args=[self.friendly_token, profile.id, encoding.id, enc_url],
                 kwargs=task_kwargs,
                 priority=priority,
-                headers={"enqueued_at": time.time()},
+                headers=inject_trace_headers({"enqueued_at": time.time()}),
             )
         except Exception:
             logger.exception(

--- a/files/query_cache.py
+++ b/files/query_cache.py
@@ -26,6 +26,8 @@ from django.conf import settings
 from django.core.cache import cache
 from django.core.serializers.json import DjangoJSONEncoder
 
+from .metrics import record_cache_operation
+
 logger = logging.getLogger(__name__)
 
 # Cache configuration
@@ -294,12 +296,15 @@ def get_cached_result(cache_key: str) -> Any | None:
         result = cache.get(cache_key, version=QUERY_CACHE_VERSION)
         if result is not None:
             logger.debug(f"Query cache HIT: {cache_key}")
+            record_cache_operation("query", "get", hit=True)
             return result
         else:
             logger.debug(f"Query cache MISS: {cache_key}")
+            record_cache_operation("query", "get", hit=False)
             return None
     except Exception as e:
         logger.warning(f"Cache get failed for {cache_key}: {e}")
+        record_cache_operation("query", "get", ok=False)
         return None
 
 
@@ -318,9 +323,11 @@ def set_cached_result(cache_key: str, data: Any, timeout: int) -> bool:
     try:
         cache.set(cache_key, data, timeout, version=QUERY_CACHE_VERSION)
         logger.debug(f"Query cache SET: {cache_key} (TTL: {timeout}s)")
+        record_cache_operation("query", "set")
         return True
     except Exception as e:
         logger.warning(f"Cache set failed for {cache_key}: {e}")
+        record_cache_operation("query", "set", ok=False)
         return False
 
 

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -24,6 +24,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from actions.models import USER_MEDIA_ACTIONS, MediaAction
+from cms.observability import inject_trace_headers, start_span
 from users.models import User
 
 from .backends import FFmpegBackend
@@ -40,6 +41,7 @@ from .helpers import (
     run_command,
 )
 from .methods import list_tasks, notify_users, pre_save_action
+from .metrics import observe_media_pipeline, record_stale_encoding
 from .models import (
     Category,
     EncodeProfile,
@@ -405,7 +407,17 @@ def encode_media(
             ffmpeg_command = [str(s) for s in ffmpeg_command]
             encoding_backend = FFmpegBackend()
             try:
-                encoding_command = encoding_backend.encode(ffmpeg_command)
+                with start_span(
+                    "media.encode.ffmpeg.start",
+                    {
+                        "media.type": media.media_type,
+                        "encoding.profile_id": profile.id,
+                        "encoding.resolution": profile.resolution,
+                        "encoding.codec": profile.codec,
+                        "encoding.extension": profile.extension,
+                    },
+                ):
+                    encoding_command = encoding_backend.encode(ffmpeg_command)
                 _duration, n_times = 0, 0
                 output = ""
                 start_time = time.time()
@@ -518,6 +530,7 @@ def encode_media(
 
         try:
             encoding.save(update_fields=["status", "logs", "progress", "total_run_time"])
+            observe_media_pipeline(media, profile, "success" if success else "fail")
         except (Encoding.DoesNotExist, django.db.DatabaseError) as e:
             logger.warning(
                 f"Failed to save final encoding state for encoding {encoding.id}: {e}. Media may have been deleted."
@@ -609,7 +622,8 @@ def whisper_transcribe(friendly_token, translate=False, notify=True):
             logger.info(f"Running ffmpeg command: {' '.join(ffmpeg_cmd)}")
 
             try:
-                ret = subprocess.run(ffmpeg_cmd, capture_output=True, shell=False)
+                with start_span("media.whisper.ffmpeg_extract", {"media.type": media.media_type}):
+                    ret = subprocess.run(ffmpeg_cmd, capture_output=True, shell=False)
                 logger.info(f"ffmpeg return code: {ret.returncode}")
 
                 if ret.returncode != 0:
@@ -658,7 +672,8 @@ def whisper_transcribe(friendly_token, translate=False, notify=True):
             logger.info(f"Running whisper command: {cmd_str}")
 
             try:
-                ret = subprocess.run(whisper_cmd, capture_output=True)
+                with start_span("media.whisper.transcribe", {"media.type": media.media_type, "translate": translate}):
+                    ret = subprocess.run(whisper_cmd, capture_output=True)
                 logger.info(f"Whisper return code: {ret.returncode}")
 
                 stdout = ret.stdout.decode("utf-8")
@@ -743,7 +758,8 @@ def produce_sprite_from_video(friendly_token):
         logger.info("failed to get media with friendly_token %s" % friendly_token)
         return {"ok": False, "reason": "media_not_found", "friendly_token": friendly_token}
 
-    result = generate_sprite_for_media(media)
+    with start_span("media.sprite.generate", {"media.type": media.media_type}):
+        result = generate_sprite_for_media(media)
     if not result["ok"]:
         logger.error(
             "Failed to generate sprite for media %s: %s%s",
@@ -943,6 +959,7 @@ def check_running_states():
             # terminate task
             # if task_id:
             # revoke(task_id, terminate=True)
+            record_stale_encoding(encoding)
             encoding.delete()
             media.encode(profiles=[profile])
             logger.info(
@@ -1834,7 +1851,7 @@ def _dispatch_deferred_encodings_inner():
                 args=[encoding.media.friendly_token, encoding.profile.id, encoding.id, enc_url],
                 kwargs=task_kwargs,
                 priority=priority,
-                headers={"enqueued_at": time.time()},
+                headers=inject_trace_headers({"enqueued_at": time.time()}),
             )
         except Exception:
             logger.exception(

--- a/files/tests/test_restricted_media_views.py
+++ b/files/tests/test_restricted_media_views.py
@@ -6,7 +6,7 @@ rate limiting, embed auth, and manifest rewriting.
 from django.test import Client, TestCase, override_settings
 
 from files.tests.helpers import create_test_media, create_test_user
-from files.token_utils import _get_brute_force_max_attempts, generate_token
+from files.token_utils import _get_brute_force_max_attempts, generate_token, reset_rate_limit
 
 
 class ViewMediaPasswordTest(TestCase):
@@ -83,6 +83,15 @@ class ViewMediaRateLimitTest(TestCase):
         self.media.set_password("correct")
         self.media.save()
         self.url = f"/view?m={self.media.friendly_token}"
+        self._reset_rate_limit_keys()
+
+    def tearDown(self):
+        self._reset_rate_limit_keys()
+        super().tearDown()
+
+    def _reset_rate_limit_keys(self):
+        for ip in ("127.0.0.1", "198.51.100.20", "203.0.113.10"):
+            reset_rate_limit(ip, self.media.friendly_token)
 
     def test_rate_limit_after_max_attempts(self):
         for _ in range(_get_brute_force_max_attempts()):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,13 @@ dependencies = [
     "django-waffle>=4.2.0,<5.0",
     "prometheus-client>=0.25.0",
     "python-json-logger>=3.0",
+    "opentelemetry-api>=1.43.0",
+    "opentelemetry-sdk>=1.43.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.43.0",
+    "opentelemetry-instrumentation-django>=0.64b0",
+    "opentelemetry-instrumentation-celery>=0.64b0",
+    "opentelemetry-instrumentation-redis>=0.64b0",
+    "opentelemetry-instrumentation-psycopg2>=0.64b0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -356,6 +356,13 @@ dependencies = [
     { name = "ipython" },
     { name = "m3u8" },
     { name = "markdown" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-celery" },
+    { name = "opentelemetry-instrumentation-django" },
+    { name = "opentelemetry-instrumentation-psycopg2" },
+    { name = "opentelemetry-instrumentation-redis" },
+    { name = "opentelemetry-sdk" },
     { name = "pep8" },
     { name = "pillow" },
     { name = "prometheus-client" },
@@ -411,6 +418,13 @@ requires-dist = [
     { name = "ipython", specifier = "==8.39.0" },
     { name = "m3u8", specifier = "==6.0.0" },
     { name = "markdown", specifier = "==3.10.2" },
+    { name = "opentelemetry-api", specifier = ">=1.43.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.43.0" },
+    { name = "opentelemetry-instrumentation-celery", specifier = ">=0.64b0" },
+    { name = "opentelemetry-instrumentation-django", specifier = ">=0.64b0" },
+    { name = "opentelemetry-instrumentation-psycopg2", specifier = ">=0.64b0" },
+    { name = "opentelemetry-instrumentation-redis", specifier = ">=0.64b0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.43.0" },
     { name = "pep8", specifier = "==1.7.1" },
     { name = "pillow", specifier = "==12.2.0" },
     { name = "prometheus-client", specifier = ">=0.25.0" },
@@ -900,6 +914,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
 name = "gprof2dot"
 version = "2025.4.14"
 source = { registry = "https://pypi.org/simple" }
@@ -1115,6 +1141,200 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/a6/d581996827b9d1133094dc347f1c4e3d2a70557973ce7a427a03337b1427/nodejs_wheel_binaries-24.14.1-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:810a48ce096925ead0690f7d143e48fb902ebfc9212097e8f6cb3ac6cbe8f314", size = 62069740, upload-time = "2026-03-31T14:07:17.006Z" },
     { url = "https://files.pythonhosted.org/packages/27/da/396d1a48cbf3d5899461bda12fa97ae4010d7e4013e7f28230cb04af5818/nodejs_wheel_binaries-24.14.1-py2.py3-none-win_amd64.whl", hash = "sha256:7a087b6a727fb9242d1cc83c8b121711bd0e9686408d27de48b34b23dfb26ac5", size = 41400067, upload-time = "2026-03-31T14:07:20.513Z" },
     { url = "https://files.pythonhosted.org/packages/13/b7/adb21cf549934579e98934531e7f9b038d583fc9c2dd4b82ea01cc31bdd2/nodejs_wheel_binaries-24.14.1-py2.py3-none-win_arm64.whl", hash = "sha256:978fdfe76624c48111ab99ed0f99f9d4c1c682e420b0212ac9e1daee52f20283", size = 39096873, upload-time = "2026-03-31T14:07:23.977Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/cc/e4c9584181f86494df0f6bdec1a4f3280c50db44704dc2a407e994fc87bb/opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1", size = 73476, upload-time = "2026-06-24T15:19:55.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/83/6dba32b85f31868400440dc7ad2ca1eab94cbbf3a7b0459ed39f8311a9e2/opentelemetry_api-1.43.0-py3-none-any.whl", hash = "sha256:20acf45e9b21851926835292e4045d290acade1edd2ff3de86d2f069687ba1fd", size = 61912, upload-time = "2026-06-24T15:19:35.434Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/c1/e8098490ab15abf116dcaf9fa89ededcb35547c7d08d4b5a62f573dc1e63/opentelemetry_exporter_otlp_proto_common-1.43.0.tar.gz", hash = "sha256:c4e32ba6d6b13bdb2b8f6764c4fd28d00192826561aa04f6d14eedfce7ac076f", size = 20197, upload-time = "2026-06-24T15:20:00.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/b2/41ebc74ae1d5859901f1b69305de58724bf043381103d6ef413521cbc35a/opentelemetry_exporter_otlp_proto_common-1.43.0-py3-none-any.whl", hash = "sha256:123c3f9cc87218562490c63b36f497bf3a722faf174a515d1443f31ababa6264", size = 17048, upload-time = "2026-06-24T15:19:41.264Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/92/0b9f56412483a8891d4843890294796c9df8ab42417bd9bad8035d840cb3/opentelemetry_exporter_otlp_proto_http-1.43.0.tar.gz", hash = "sha256:fa8a42bb7d00ee5391f4c0b04d8e6a46c03caa437903296ab73a81dc11ba118f", size = 25406, upload-time = "2026-06-24T15:20:01.515Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/20/b685ed7af2e17c29ffc8af56f1fa8bc2033258fc30fb0d2b722f49d13ba0/opentelemetry_exporter_otlp_proto_http-1.43.0-py3-none-any.whl", hash = "sha256:647f603aa8efdbdb4dbff842e0729d0406a6fff26b295a72d3d60e7d963b2610", size = 21795, upload-time = "2026-06-24T15:19:43.164Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/97/02fe6e1c8b1ffac42d0b429c18080edb24e0e0d18c86612edf72b5752382/opentelemetry_instrumentation-0.64b0.tar.gz", hash = "sha256:b47d528dead6271d7743114417eb67fc915bd9258111c48dbf9a4951d2efa88d", size = 41935, upload-time = "2026-06-24T15:19:12.951Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/0c/cb9fe342de5299c7af24582eb7d788661cc53a1c4b904da92309caaa9417/opentelemetry_instrumentation-0.64b0-py3-none-any.whl", hash = "sha256:133ab7ffca796557aec059bf6be3190a34b6dea987f25be3d9409e230cbdad8b", size = 35880, upload-time = "2026-06-24T15:18:17.277Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-celery"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/96/76c25b05c1e42793a0d9b78fbb383199fcf447b3b06ef7af6a518f3c8252/opentelemetry_instrumentation_celery-0.64b0.tar.gz", hash = "sha256:730e4ef8842861855dadc54c02b0fc3cf453c7d2b189a7125382a30e5d342e24", size = 15519, upload-time = "2026-06-24T15:19:22.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/7f/c29233f0af2eaf41a015c3e143551cc70c47a97a1bc6e830b6712066c783/opentelemetry_instrumentation_celery-0.64b0-py3-none-any.whl", hash = "sha256:ef21be15d603ac84e15a0394c551a1d25721d31c24f0dcf3a9832dd7b7e06807", size = 13169, upload-time = "2026-06-24T15:18:30.747Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-dbapi"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/9f/3c6ce6f4394faa1540f48b7d442f455582ca76449952506ce767a54f09bf/opentelemetry_instrumentation_dbapi-0.64b0.tar.gz", hash = "sha256:8e3a1528fc9753a04190a7e7bf0180c5abd059f3aa68ec3857edb363c9847c44", size = 20138, upload-time = "2026-06-24T15:19:24.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/1b/77972514bcc046741339b76e2cc104bef536c1433b45a2b39adbdadc9889/opentelemetry_instrumentation_dbapi-0.64b0-py3-none-any.whl", hash = "sha256:1caa96d438bf37f71dd778c9f1e03ba1f50b8ab54aeef68b2a630c93c05cddc6", size = 14812, upload-time = "2026-06-24T15:18:33.541Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-django"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-wsgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/2e/8f6084eab186533b0574683a8c39e51803e6c34c21fc33e194f58352d704/opentelemetry_instrumentation_django-0.64b0.tar.gz", hash = "sha256:3d2673b4f77156b15b1b119c8849b50e3644cfc325f7a24c03602596de2dbba4", size = 25387, upload-time = "2026-06-24T15:19:24.795Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/ef/7e7857fae434e0eb0395d8a5b399c21efd23fe0f3c166ecdcb8596902541/opentelemetry_instrumentation_django-0.64b0-py3-none-any.whl", hash = "sha256:c1f628e53c22aa8f9cc9cbe6e61e781940da6eda5f910d26720ef8ac73e25afe", size = 18938, upload-time = "2026-06-24T15:18:34.449Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-psycopg2"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-dbapi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/2d/0062ecf86b6bd407398820ae34d8acf7259f2b32531fa22e1c3b7748c6d0/opentelemetry_instrumentation_psycopg2-0.64b0.tar.gz", hash = "sha256:57df449718297b93e7bb57c76d3439c475eb5a5451600fcd6a9024d74822d972", size = 12065, upload-time = "2026-06-24T15:19:33.994Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/e8/961677ce65cd5065646d90dfa8a7d780b782fefe3c8effdf4b91691e339d/opentelemetry_instrumentation_psycopg2-0.64b0-py3-none-any.whl", hash = "sha256:9a41b5f094f19b87e7dddf1d6f03f1bf956620faaa918fc1987dbd53e73f9b98", size = 10790, upload-time = "2026-06-24T15:18:48.693Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-redis"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/89/9b556b53faf2b5a23f2bb844e087e6577704129bd5964decc3fb9d7a1309/opentelemetry_instrumentation_redis-0.64b0.tar.gz", hash = "sha256:c37e194c1e8ff59944d5c2f18014ee18f244a103958b1f2482099525ae9099f9", size = 17045, upload-time = "2026-06-24T15:19:38.281Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/f2/96cd02f91303ea0d387aa46c615365877875ca47f9796e9fb1503ec1e0e6/opentelemetry_instrumentation_redis-0.64b0-py3-none-any.whl", hash = "sha256:5458a541986f665b9d7e641421fa5d0c286f1813b452faab6f84503823719d52", size = 14642, upload-time = "2026-06-24T15:18:54.141Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-wsgi"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/4f/0b5232a0d635eee5da7c85af503d2f00fdcac61cc6d4d4a69aadf1fa7a0e/opentelemetry_instrumentation_wsgi-0.64b0.tar.gz", hash = "sha256:1cce6ea28d1800c154e6ccdf52f05bae2f05c5e28ee44f0dddb17ada26208986", size = 19667, upload-time = "2026-06-24T15:19:46.407Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/5d/4da612cfe1ad96730dba19c9ab97f531be0558a918998e11478734cb36b2/opentelemetry_instrumentation_wsgi-0.64b0-py3-none-any.whl", hash = "sha256:5a3b0174f39072c0abb749be4ae7e469c7585e87cdfaf63665657b1a7058c105", size = 13787, upload-time = "2026-06-24T15:19:05.417Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b9/d357faefb40bda1d4799913e6af611171ff22a2dedcb93576bc92242d056/opentelemetry_proto-1.43.0.tar.gz", hash = "sha256:224778df17e1f3fafeaaa21d874236ca5f6ffc2f86e0899298ec7351aac27924", size = 46481, upload-time = "2026-06-24T15:20:07.625Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/a7/3e5308cf548b8f72529c7db1afdb3a404211982376a12927fd7759f77bf3/opentelemetry_proto-1.43.0-py3-none-any.whl", hash = "sha256:c58f1f7ef84bc7dc2834016c0c37fe0081dde7ca9f6339be1970fbf9cdaaa90d", size = 72489, upload-time = "2026-06-24T15:19:51.164Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/eb/5041074274ac0956b03637cc039d434569112468e875eddfcc9a0674ce06/opentelemetry_sdk-1.43.0.tar.gz", hash = "sha256:d8187c81c162df9913e4003dd6485f7390d9a24fc17026ec7387b8b8218b08e9", size = 254744, upload-time = "2026-06-24T15:20:08.467Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/e3/b17be23af124201c9f52eececd4cc8ddfed1597d37b4ee771895d325805c/opentelemetry_sdk-1.43.0-py3-none-any.whl", hash = "sha256:d1323a547c1ce69d6a069a17a44b7da82bb8b332051ecb074041f87642c86823", size = 178852, upload-time = "2026-06-24T15:19:52.169Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/30/5f26df29509eccd86b99b481ac9ffa39da49ba9577cc69071c552ae30447/opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c", size = 148340, upload-time = "2026-06-24T15:20:09.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/ca/23ba87a221b574a7c5a99d48849d80bfe8b047624681357e2b002e566187/opentelemetry_semantic_conventions-0.64b0-py3-none-any.whl", hash = "sha256:ea77e85e354b8f604ddbe5f3d9135216f982fa4d77e5859ac30f6d8a50505aa6", size = 203713, upload-time = "2026-06-24T15:19:53.339Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/1b/1029a805fd7242f7dfce91633b244c3b14a94d703232878f71e01ce862b1/opentelemetry_util_http-0.64b0.tar.gz", hash = "sha256:8a86a220dbfc56d736f47f1e5c4e7932a21fcf69052312e1bcf166444dc79322", size = 11102, upload-time = "2026-06-24T15:19:48.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/c7/5f8ec5b30546f2dc22cd5fc5759bce2ab5be6e89a2e710a405ac9ef64ed3/opentelemetry_util_http-0.64b0-py3-none-any.whl", hash = "sha256:c1e5350d25507c1afcd6076cf9ac062485a0a4f79cd9971366996fd3056bacdb", size = 8204, upload-time = "2026-06-24T15:19:09.02Z" },
 ]
 
 [[package]]
@@ -1338,6 +1558,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
 ]
 
 [[package]]
@@ -1918,4 +2153,90 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cb/2a/55b3f3a4ec326cd077c1c3defeee656b9298372a69229134d930151acd01/whitenoise-6.12.0.tar.gz", hash = "sha256:f723ebb76a112e98816ff80fcea0a6c9b8ecde835f8ddda25df7a30a3c2db6ad", size = 26841, upload-time = "2026-02-27T00:05:42.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/eb/d5583a11486211f3ebd4b385545ae787f32363d453c19fffd81106c9c138/whitenoise-6.12.0-py3-none-any.whl", hash = "sha256:fc5e8c572e33ebf24795b47b6a7da8da3c00cff2349f5b04c02f28d0cc5a3cc2", size = 20302, upload-time = "2026-02-27T00:05:40.086Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/8b/59781d0fe7b0adfbea37f600857de4be68921e454aeecf1a11bda35cdccc/wrapt-2.2.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:055e6fcfaa28e58c6a8c247d48b92be9d56f818b7068aa4f22b15b3343a09931", size = 80556, upload-time = "2026-06-20T23:47:28.473Z" },
+    { url = "https://files.pythonhosted.org/packages/94/dc/66c61aca927230c9cf97a3cb005c803971a1076ff9f7d61085d035c20085/wrapt-2.2.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8374eb6b1a58809211e84ff835a182bb17ab2807a5bfef23204c8cff38178a00", size = 81648, upload-time = "2026-06-20T23:47:30.504Z" },
+    { url = "https://files.pythonhosted.org/packages/23/1b/545eee1c18f3af4cf140bb5822b6ef81ebe569df0a63ac109973103a30a5/wrapt-2.2.2-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:656593bb3f5529f03d27af4136c4d7b11990e470bcbc6fefa5ef218695bece55", size = 152956, upload-time = "2026-06-20T23:47:31.867Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a7/6f42a3d03e44dc612a5dcff324e7366075a7857f0be2d49a8cb8a68279b8/wrapt-2.2.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfb00cb7bb22099e2f64b7340fb96113639aa7260c0972af3797ace2297b936c", size = 154771, upload-time = "2026-06-20T23:47:33.352Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/55/4d76175aaa97523c38f1d28f79d18ab41a1b116814158a818bc0eba00571/wrapt-2.2.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e7f10ee0bd53673bfd52b67cbce83336fe6cad90d2377b03baf66491d2bbfb91", size = 149460, upload-time = "2026-06-20T23:47:34.712Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9b/12e23264d8f4735e8483262f95c5a6b03c3665fd2a84bdf99a45b6a2f4ec/wrapt-2.2.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4402f57c5f0d0579599858ffbdd9bf4e3f0972f51096f2bd6cc7dab6b76ee49e", size = 153648, upload-time = "2026-06-20T23:47:36.092Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a3/bcd5ec37289dcd85ecd4d15395a6a6063d60bc45ff94a9d77814e1e54d64/wrapt-2.2.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:3a4eb7964ff4643d333c84f880bcf554652b2a1050aebc54ae696327f61acfaf", size = 148502, upload-time = "2026-06-20T23:47:37.623Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/be/716d708f607fa70f8a6eb47dff8ee945d5278dfc89ffeeff33039d052e63/wrapt-2.2.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e542b7c5af91e2123a8aabf19894319d5ec4268d2a9ffd2f239386133fc47746", size = 152238, upload-time = "2026-06-20T23:47:39.118Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/c0/1a48e7e54501274f5d906f18372221b13183b0afbb5b8bb4c7ca0392c0b4/wrapt-2.2.2-cp310-cp310-win32.whl", hash = "sha256:6e7e45b43d3c774d244fe7264378f5a3f0f383bc55a54a9866434e524540110f", size = 77278, upload-time = "2026-06-20T23:47:40.476Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/82/9cd69a1af288fbdedf01a10e3c8a0b6890b08c7f3f96d36a213699dbcd94/wrapt-2.2.2-cp310-cp310-win_amd64.whl", hash = "sha256:955f1d6e72a352e478de8d8b503abe301c5e139a141b62eb0923bd694995025f", size = 80131, upload-time = "2026-06-20T23:47:41.785Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/73/8db7e27daef37ae70a53ea62bef7fe80cc51a8b5e9e9181a8be6eb9a999c/wrapt-2.2.2-cp310-cp310-win_arm64.whl", hash = "sha256:b89d8d73c82db2bb7e6090b3afd7973f980d24e905cc34394eab60b884b3bf67", size = 79615, upload-time = "2026-06-20T23:47:43.109Z" },
+    { url = "https://files.pythonhosted.org/packages/27/15/0c2d55168707465abfc41f33c0b23d792a5fa9b65c26983606940900a120/wrapt-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f1a2ff355ece6a111ca7a20dc86df6659c9205d3fcee674ca34f2a2854fd4e73", size = 80782, upload-time = "2026-06-20T23:47:44.367Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b5/5c0b093eb48f8a062ef6267d3cb36e9bb1b88440181f6545a383c60efdf8/wrapt-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55b9a899e6fff5444f229d30aa6e9ac92d2216d9d60f33c771b5d76a760d5f8e", size = 81678, upload-time = "2026-06-20T23:47:45.857Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f3/de70937472dd3e8a4e6811192f9c6075efdffd4a2cd9b4596bf160f89668/wrapt-2.2.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a2d78c363f97d8bd718ee40432c66395685e9e98528ccaa423c3355d1715a26d", size = 159671, upload-time = "2026-06-20T23:47:47.345Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/40aed2330e7f02ecf74386ffcfef9ccb7108c6a430f15b6a252b663b1bed/wrapt-2.2.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d619e1eed9bd4f6ed9f24cd61971aa086fa86505289628d464bcf8a2c2e3f328", size = 160785, upload-time = "2026-06-20T23:47:48.759Z" },
+    { url = "https://files.pythonhosted.org/packages/45/04/aa5309beed5344b00220ae6b3b24055852192656194c27947bee1736306a/wrapt-2.2.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:518b0c5e323511ec56a38894802ddd5e1222626484e68efe63f201854ad788e5", size = 153699, upload-time = "2026-06-20T23:47:50.177Z" },
+    { url = "https://files.pythonhosted.org/packages/01/df/2def7e99d1fe87eea413f95f671924cdddcb08823b1ffd212748dfa6d062/wrapt-2.2.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4bccea5cdecffa9dd70e343741f0e41e0a16619313d04b72f78bb525162ebcd0", size = 159695, upload-time = "2026-06-20T23:47:51.602Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f6/a906d01a2ce12157bad2404957b3e2140da354b8a70b2fa48bbf282871c0/wrapt-2.2.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:209112cafd963710a05d199aae431d79a28bc76eb8e6d1bbbb8ad24340722cae", size = 152813, upload-time = "2026-06-20T23:47:53.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/49/bc0086292d239575b4c08f4cf8a4079fa58abbad58ec23abf84833a283ed/wrapt-2.2.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e5a5290e4bf2f332fc29ce72ffb9a2fff678aaac047e2e9f5f7165cd7792e099", size = 158809, upload-time = "2026-06-20T23:47:54.391Z" },
+    { url = "https://files.pythonhosted.org/packages/55/83/8fbd034de1f3e907edaa18786d5dd8f6932874edee0826c7cecb5cab03a1/wrapt-2.2.2-cp311-cp311-win32.whl", hash = "sha256:5499236ad1dc116012e2a5dd943f3f31af12fce452128e2bbcbd55a7d3d4d14c", size = 77414, upload-time = "2026-06-20T23:47:55.882Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/9c/23695baa331c6de4e874c3d78b8e0bed92e1d2a274e665b29858f6841672/wrapt-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:8636809939152be6ae20a6cef0fed9fe60f411b47847d0426a826884b469e971", size = 80368, upload-time = "2026-06-20T23:47:57.237Z" },
+    { url = "https://files.pythonhosted.org/packages/08/49/40cefc342bf89b234a4490d741290fce781774b831aefb39c25471da96c9/wrapt-2.2.2-cp311-cp311-win_arm64.whl", hash = "sha256:5d0a142f7af07caeb5e5da87493162a7b8efa19ba919e550a746f7446e13fb30", size = 79489, upload-time = "2026-06-20T23:47:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
+    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
+    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]


### PR DESCRIPTION
## Summary
- add settings.py-based OpenTelemetry bootstrap with disabled-by-default tracing and JSON trace/span log fields
- add low-cardinality HTTP, Celery, media pipeline, cache, auth, and runtime scrape metrics
- propagate trace headers through existing Celery dispatch paths while preserving enqueued_at

## Validation
- uv run python -m py_compile cms/observability.py cms/observability_middleware.py cms/tests/test_observability.py cms/settings.py cms/urls.py cms/wsgi.py cms/celery.py files/metrics.py files/tasks.py files/models.py files/cache_utils.py files/query_cache.py
- uv run python manage.py check
- uv run python manage.py test cms.tests.test_observability -v 2
- uv run ruff check cms/observability.py cms/observability_middleware.py cms/tests/test_observability.py cms/settings.py cms/urls.py cms/wsgi.py cms/celery.py files/metrics.py files/tasks.py files/models.py files/cache_utils.py files/query_cache.py
- uv run ruff format --check cms/observability.py cms/observability_middleware.py cms/tests/test_observability.py files/metrics.py files/tasks.py files/models.py files/cache_utils.py files/query_cache.py cms/celery.py cms/wsgi.py cms/urls.py
- uv run pre-commit run --all-files

## Verification boundary
- Full local Django suite with uv run python manage.py test --keepdb is blocked by local PostgreSQL password authentication for user cinematacms.

Stacked on django-observability; retarget after the base branch merges.